### PR TITLE
Add config loader and documentation

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,7 @@
+# Code Change Checklist
+
+- [x] Added Poetry configuration via `pyproject.toml`
+- [x] Implemented configuration loader utility
+- [x] Created demo script and configuration
+- [x] Added comprehensive documentation under `docs/`
+- [x] Added unit tests for new functionality

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive data loading module for Databricks that provides parallel file processing with multiple loading strategies, file tracking, and robust error handling.
 
+New users should start with the [Quickstart guide](docs/quickstart.md) which
+explains installation using **Poetry** and demonstrates the configuration
+workflow using a small demo.
+
 ## Features
 
 - **File Monitoring**: Automatically discovers and processes new files from configured locations
@@ -40,19 +44,28 @@ data_loader/
 
 ## Installation
 
-1. Install the package:
+1. Install dependencies with **Poetry**:
 ```bash
-pip install -e .
+poetry install
 ```
 
-2. Install dependencies:
+2. (Optional) Activate the virtual environment created by Poetry:
 ```bash
-pip install -r requirements.txt
+poetry shell
 ```
 
 ## Configuration
 
 The data loader uses JSON configuration files to define tables, loading strategies, and processing options.
+
+You can load a configuration file programmatically using
+`load_config_from_file`:
+
+```python
+from data_loader.config import load_config_from_file
+
+config = load_config_from_file("path/to/config.json")
+```
 
 ### Example Configuration
 

--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -13,12 +13,20 @@ __author__ = "Infinit3Labs"
 
 # Import only non-Spark dependent modules by default
 # Spark-dependent modules should be imported on-demand
-from .config.table_config import DataLoaderConfig, TableConfig, LoadingStrategy
+from .config.table_config import (
+    DataLoaderConfig,
+    TableConfig,
+    LoadingStrategy,
+    EXAMPLE_CONFIG,
+    load_config_from_file,
+)
 
 __all__ = [
     "DataLoaderConfig",
     "TableConfig", 
     "LoadingStrategy",
+    "EXAMPLE_CONFIG",
+    "load_config_from_file",
 ]
 
 # Provide easy access to main components when PySpark is available

--- a/data_loader/config/__init__.py
+++ b/data_loader/config/__init__.py
@@ -1,1 +1,17 @@
-"""Configuration package for data loader."""
+"""Configuration helpers for the data loader."""
+
+from .table_config import (
+    DataLoaderConfig,
+    TableConfig,
+    LoadingStrategy,
+    EXAMPLE_CONFIG,
+    load_config_from_file,
+)
+
+__all__ = [
+    "DataLoaderConfig",
+    "TableConfig",
+    "LoadingStrategy",
+    "EXAMPLE_CONFIG",
+    "load_config_from_file",
+]

--- a/data_loader/config/table_config.py
+++ b/data_loader/config/table_config.py
@@ -7,6 +7,13 @@ Defines table schemas, loading strategies, and processing rules.
 from enum import Enum
 from typing import Dict, List, Optional, Any
 from pydantic import BaseModel, Field
+from pathlib import Path
+import json
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
 
 class LoadingStrategy(str, Enum):
@@ -120,3 +127,16 @@ EXAMPLE_CONFIG = {
         }
     ]
 }
+
+
+def load_config_from_file(path: str) -> DataLoaderConfig:
+    """Load a :class:`DataLoaderConfig` from a JSON or YAML file."""
+    file_path = Path(path)
+    with open(file_path, "r", encoding="utf-8") as fh:
+        if file_path.suffix.lower() in {".yml", ".yaml"}:
+            if yaml is None:
+                raise ImportError("pyyaml is required to load YAML configuration files")
+            data = yaml.safe_load(fh)
+        else:
+            data = json.load(fh)
+    return DataLoaderConfig(**data)

--- a/data_loader/config/table_config.py
+++ b/data_loader/config/table_config.py
@@ -12,7 +12,7 @@ import json
 
 try:
     import yaml
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     yaml = None
 
 

--- a/data_loader/tests/test_basic.py
+++ b/data_loader/tests/test_basic.py
@@ -3,13 +3,20 @@ Basic tests for the data loader functionality.
 """
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from data_loader.config.databricks_config import DatabricksConfig
 from data_loader.config.table_config import (
     DataLoaderConfig, TableConfig, LoadingStrategy, EXAMPLE_CONFIG
 )
 from data_loader.strategies.base_strategy import BaseLoadingStrategy
 from data_loader.strategies.append_strategy import AppendStrategy
 from data_loader.strategies.scd2_strategy import SCD2Strategy
+
+
+@pytest.fixture(autouse=True)
+def disable_spark(monkeypatch):
+    """Replace Spark session with a mock to avoid initializing PySpark."""
+    monkeypatch.setattr(DatabricksConfig, "spark", property(lambda self: Mock()))
 
 
 class TestTableConfig:

--- a/data_loader/tests/test_config_loader.py
+++ b/data_loader/tests/test_config_loader.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from data_loader.config import load_config_from_file, DataLoaderConfig
+
+
+def test_load_config_from_json(tmp_path):
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(
+        '{"raw_data_path": "./raw", "processed_data_path": "./proc", "checkpoint_path": "./chk", "tables": []}'
+    )
+
+    cfg = load_config_from_file(str(cfg_path))
+    assert isinstance(cfg, DataLoaderConfig)
+    assert cfg.raw_data_path == "./raw"
+
+
+def test_load_config_from_yaml(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        "raw_data_path: ./raw\nprocessed_data_path: ./proc\ncheckpoint_path: ./chk\ntables: []\n"
+    )
+
+    cfg = load_config_from_file(str(cfg_path))
+    assert cfg.processed_data_path == "./proc"

--- a/demo/demo_config.json
+++ b/demo/demo_config.json
@@ -1,0 +1,23 @@
+{
+  "raw_data_path": "./demo/raw/",
+  "processed_data_path": "./demo/processed/",
+  "checkpoint_path": "./demo/checkpoints/",
+  "file_tracker_table": "file_processing_tracker",
+  "file_tracker_database": "metadata",
+  "max_parallel_jobs": 1,
+  "retry_attempts": 1,
+  "timeout_minutes": 30,
+  "log_level": "INFO",
+  "enable_metrics": true,
+  "tables": [
+    {
+      "table_name": "sample_table",
+      "database_name": "demo",
+      "source_path_pattern": "./demo/raw/sample/*.parquet",
+      "loading_strategy": "append",
+      "file_format": "parquet",
+      "schema_evolution": true,
+      "partition_columns": ["date"]
+    }
+  ]
+}

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -1,0 +1,20 @@
+"""Demo script showcasing configuration driven usage of the data loader."""
+from pathlib import Path
+from data_loader.config import load_config_from_file
+from data_loader.utils.logger import setup_logging
+
+
+def main() -> None:
+    config_path = Path(__file__).parent / "demo_config.json"
+    config = load_config_from_file(str(config_path))
+
+    setup_logging(config.log_level)
+
+    print("Configuration loaded with", len(config.tables), "table(s)")
+    print("This demo does not execute Spark jobs but illustrates the workflow.")
+    for table in config.tables:
+        print(f"- {table.table_name} from pattern {table.source_path_pattern}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart
+
+This guide helps you get the data loader running using **Poetry**.
+
+## Installation
+
+```bash
+# Install dependencies
+poetry install
+
+# Run tests to verify the installation
+poetry run pytest
+```
+
+## Running the demo
+
+```bash
+# Execute the demo script
+poetry run python demo/run_demo.py
+```
+
+The demo uses `demo/demo_config.json` to showcase the configuration driven
+workflow. Edit this file to experiment with different settings.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,37 @@
+# Configuration Templates
+
+Below are example configuration snippets that can be reused in your own
+projects.
+
+## Basic Table Configuration
+```json
+{
+  "table_name": "my_table",
+  "database_name": "analytics",
+  "source_path_pattern": "/path/to/files/*.parquet",
+  "loading_strategy": "append",
+  "file_format": "parquet",
+  "schema_evolution": true,
+  "partition_columns": ["date"]
+}
+```
+
+## Full Data Loader Configuration
+```json
+{
+  "raw_data_path": "/data/raw/",
+  "processed_data_path": "/data/processed/",
+  "checkpoint_path": "/data/checkpoints/",
+  "tables": [
+    {
+      "table_name": "customers",
+      "database_name": "analytics",
+      "source_path_pattern": "/data/raw/customers/*.parquet",
+      "loading_strategy": "scd2",
+      "primary_keys": ["customer_id"],
+      "tracking_columns": ["name", "email"],
+      "partition_columns": ["country"]
+    }
+  ]
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "databricks-data-loader"
 version = "0.1.0"
 description = "A parallel data loading module for Databricks with file monitoring and multiple loading strategies"
-authors = ["Infinit3Labs <info@example.com>"]
+authors = ["Infinit3Labs <contact@infinit3labs.com>"]
 readme = "README.md"
 license = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "databricks-data-loader"
+version = "0.1.0"
+description = "A parallel data loading module for Databricks with file monitoring and multiple loading strategies"
+authors = ["Infinit3Labs <info@example.com>"]
+readme = "README.md"
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pyspark = ">=3.0.0"
+delta-spark = ">=2.0.0"
+pydantic = ">=2.0.0"
+typer = ">=0.9.0"
+loguru = ">=0.7.0"
+pyyaml = "^6.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0.0"
+pytest-cov = ">=4.0.0"
+black = ">=23.0.0"
+flake8 = ">=6.0.0"
+mypy = ">=1.0.0"
+
+[tool.poetry.scripts]
+databricks-data-loader = "data_loader.main:main"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- use Poetry for package management
- add a helper to load config files
- document quickstart steps and templates
- provide a demo configuration and script
- include a checklist and tests for the new loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687caef7e2b8832697c135a21ea9aa35