### PR TITLE
Add Databricks job runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,13 @@ Enable debug logging for detailed execution information:
 python -m data_loader.main run --config config.json --log-level DEBUG
 ```
 
+
+## Databricks Job Execution
+For running the loader as a Databricks job, use the `data_loader.job_runner` module. Configure widgets `config`, `log_level`, `optimize` and `vacuum` or set the environment variables `DATALOADER_CONFIG_FILE` etc. See `docs/databricks_job.md` for details.
+
 ## Contributing
+
+
 
 1. Fork the repository
 2. Create a feature branch

--- a/data_loader/job_runner.py
+++ b/data_loader/job_runner.py
@@ -1,0 +1,88 @@
+"""Databricks Job Runner integration.
+
+This module provides utilities to run the data loader inside a
+Databricks job. Parameters can be provided either via Databricks
+widgets or environment variables so that the same code works when
+executed locally for testing.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Any
+
+from loguru import logger
+
+try:
+    from pyspark.sql import SparkSession
+    from pyspark.dbutils import DBUtils
+except Exception:  # pragma: no cover - Spark not available in tests
+    SparkSession = None
+    DBUtils = None
+
+from .config.table_config import DataLoaderConfig
+from .main import load_configuration, print_processing_summary
+from .utils.logger import setup_logging
+
+
+def _get_dbutils():
+    """Return DBUtils instance if running on Databricks."""
+    if SparkSession is None or DBUtils is None:
+        return None
+    try:
+        spark = SparkSession.builder.getOrCreate()
+        return DBUtils(spark)
+    except Exception:
+        return None
+
+
+def load_job_params(defaults: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Load job parameters from widgets or environment variables."""
+    params = defaults.copy() if defaults else {}
+    dbutils = _get_dbutils()
+
+    def _get_param(name: str, env_name: str, default: str | None = None) -> str | None:
+        if dbutils:
+            try:
+                return dbutils.widgets.get(name)
+            except Exception:
+                pass
+        return os.getenv(env_name, default)
+
+    params["config_file"] = _get_param("config", "DATALOADER_CONFIG_FILE")
+    params["log_level"] = _get_param("log_level", "DATALOADER_LOG_LEVEL", "INFO")
+    params["optimize"] = _get_param("optimize", "DATALOADER_OPTIMIZE", "false")
+    params["vacuum"] = _get_param("vacuum", "DATALOADER_VACUUM", "false")
+
+    return params
+
+
+def run_job() -> Dict[str, Any]:
+    """Entry point used by Databricks jobs."""
+    job_params = load_job_params()
+    config_file = job_params.get("config_file")
+    log_level = job_params.get("log_level", "INFO")
+    optimize = str(job_params.get("optimize", "false")).lower() == "true"
+    vacuum = str(job_params.get("vacuum", "false")).lower() == "true"
+
+    setup_logging(log_level=log_level)
+
+    if not config_file:
+        raise ValueError("Configuration file must be provided via widget or env var")
+
+    config: DataLoaderConfig = load_configuration(config_file=config_file)
+    from .core.processor import DataProcessor  # imported lazily
+
+    processor = DataProcessor(config)
+    results = processor.process_all_tables()
+    print_processing_summary(results)
+
+    if optimize:
+        processor.optimize_all_tables()
+    if vacuum:
+        processor.vacuum_all_tables()
+
+    return results
+
+
+__all__ = ["run_job", "load_job_params"]

--- a/data_loader/job_runner.py
+++ b/data_loader/job_runner.py
@@ -16,7 +16,7 @@ from loguru import logger
 try:
     from pyspark.sql import SparkSession
     from pyspark.dbutils import DBUtils
-except Exception:  # pragma: no cover - Spark not available in tests
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - Spark not available in tests
     SparkSession = None
     DBUtils = None
 

--- a/data_loader/job_runner.py
+++ b/data_loader/job_runner.py
@@ -38,7 +38,7 @@ def _get_dbutils():
 
 def load_job_params(defaults: Dict[str, Any] | None = None) -> Dict[str, Any]:
     """Load job parameters from widgets or environment variables."""
-    params = defaults.copy() if defaults else {}
+    params = defaults or {}
     dbutils = _get_dbutils()
 
     def _get_param(name: str, env_name: str, default: str | None = None) -> str | None:

--- a/data_loader/job_runner.py
+++ b/data_loader/job_runner.py
@@ -45,7 +45,7 @@ def load_job_params(defaults: Dict[str, Any] | None = None) -> Dict[str, Any]:
         if dbutils:
             try:
                 return dbutils.widgets.get(name)
-            except Exception:
+            except (KeyError, AttributeError):
                 pass
         return os.getenv(env_name, default)
 

--- a/data_loader/job_runner.py
+++ b/data_loader/job_runner.py
@@ -32,7 +32,7 @@ def _get_dbutils():
     try:
         spark = SparkSession.builder.getOrCreate()
         return DBUtils(spark)
-    except Exception:
+    except (ImportError, RuntimeError):
         return None
 
 

--- a/data_loader/tests/test_basic.py
+++ b/data_loader/tests/test_basic.py
@@ -10,6 +10,7 @@ from data_loader.config.table_config import (
 from data_loader.strategies.base_strategy import BaseLoadingStrategy
 from data_loader.strategies.append_strategy import AppendStrategy
 from data_loader.strategies.scd2_strategy import SCD2Strategy
+from data_loader.config.databricks_config import databricks_config
 
 
 class TestTableConfig:
@@ -71,7 +72,8 @@ class TestTableConfig:
 class TestAppendStrategy:
     """Test append loading strategy."""
     
-    def test_strategy_creation(self):
+    @patch.object(databricks_config, "_create_spark_session", return_value=Mock())
+    def test_strategy_creation(self, _mock_spark):
         """Test append strategy creation."""
         table_config = TableConfig(
             table_name="test_table",
@@ -84,7 +86,8 @@ class TestAppendStrategy:
         assert strategy.table_config == table_config
         assert strategy.full_table_name == "test_db.test_table"
     
-    def test_config_validation(self):
+    @patch.object(databricks_config, "_create_spark_session", return_value=Mock())
+    def test_config_validation(self, _mock_spark):
         """Test configuration validation."""
         table_config = TableConfig(
             table_name="test_table",
@@ -111,7 +114,8 @@ class TestAppendStrategy:
 class TestSCD2Strategy:
     """Test SCD2 loading strategy."""
     
-    def test_strategy_creation(self):
+    @patch.object(databricks_config, "_create_spark_session", return_value=Mock())
+    def test_strategy_creation(self, _mock_spark):
         """Test SCD2 strategy creation with valid configuration."""
         table_config = TableConfig(
             table_name="test_table",
@@ -126,7 +130,8 @@ class TestSCD2Strategy:
         assert strategy.table_config == table_config
         assert strategy.full_table_name == "test_db.test_table"
     
-    def test_config_validation_success(self):
+    @patch.object(databricks_config, "_create_spark_session", return_value=Mock())
+    def test_config_validation_success(self, _mock_spark):
         """Test successful SCD2 configuration validation."""
         table_config = TableConfig(
             table_name="test_table",
@@ -143,7 +148,8 @@ class TestSCD2Strategy:
         strategy = SCD2Strategy(table_config)
         assert strategy.validate_config() is True
     
-    def test_config_validation_failure(self):
+    @patch.object(databricks_config, "_create_spark_session", return_value=Mock())
+    def test_config_validation_failure(self, _mock_spark):
         """Test SCD2 configuration validation failures."""
         # Missing primary keys
         with pytest.raises(ValueError):

--- a/data_loader/tests/test_job_runner.py
+++ b/data_loader/tests/test_job_runner.py
@@ -1,0 +1,28 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_loader.job_runner import load_job_params
+
+
+def test_load_job_params_env(monkeypatch):
+    monkeypatch.setenv("DATALOADER_CONFIG_FILE", "/tmp/config.json")
+    monkeypatch.setenv("DATALOADER_LOG_LEVEL", "DEBUG")
+    params = load_job_params()
+    assert params["config_file"] == "/tmp/config.json"
+    assert params["log_level"] == "DEBUG"
+
+
+def test_load_job_params_widgets(monkeypatch):
+    fake_dbutils = MagicMock()
+    fake_dbutils.widgets.get.side_effect = lambda n: {
+        "config": "/dbfs/config.json",
+        "log_level": "INFO",
+        "optimize": "true",
+        "vacuum": "false",
+    }[n]
+    with patch("data_loader.job_runner._get_dbutils", return_value=fake_dbutils):
+        params = load_job_params()
+    assert params["config_file"] == "/dbfs/config.json"
+    assert params["optimize"] == "true"

--- a/demo_databricks_job.py
+++ b/demo_databricks_job.py
@@ -1,0 +1,12 @@
+"""Demonstration of running the job runner locally."""
+import os
+from data_loader.job_runner import run_job
+
+# Point to the example configuration for demonstration
+os.environ.setdefault("DATALOADER_CONFIG_FILE", "./example_config.json")
+
+if __name__ == "__main__":
+    try:
+        run_job()
+    except Exception as exc:
+        print(f"Job run failed: {exc}")

--- a/docs/change_checklist.md
+++ b/docs/change_checklist.md
@@ -1,0 +1,7 @@
+# Developer Checklist
+
+- [ ] Update or create unit tests for all new functionality
+- [ ] Run `pytest` and ensure all tests pass
+- [ ] Document new features in `docs/`
+- [ ] Update example or demo scripts
+- [ ] Bump version in `pyproject.toml` if publishing

--- a/docs/databricks_job.md
+++ b/docs/databricks_job.md
@@ -1,0 +1,26 @@
+# Running as a Databricks Job
+
+The `data_loader.job_runner` module provides an entry point for running the
+loader on a Databricks cluster. Parameters are supplied via Databricks widgets
+or environment variables so the same script can be executed locally.
+
+## Required Widgets / Environment Variables
+
+- `config` / `DATALOADER_CONFIG_FILE` – path to the JSON configuration file
+- `log_level` / `DATALOADER_LOG_LEVEL` – log level (default: `INFO`)
+- `optimize` / `DATALOADER_OPTIMIZE` – set to `true` to run table optimization
+- `vacuum` / `DATALOADER_VACUUM` – set to `true` to run table vacuum
+
+## Usage
+
+```bash
+# On Databricks, create widgets in a notebook and run
+%run /path/to/job
+```
+
+Locally the job can be executed by setting environment variables:
+
+```bash
+export DATALOADER_CONFIG_FILE=./config.json
+python -m data_loader.job_runner
+```

--- a/example_config.json
+++ b/example_config.json
@@ -1,0 +1,44 @@
+{
+  "raw_data_path": "/mnt/raw/",
+  "processed_data_path": "/mnt/processed/",
+  "checkpoint_path": "/mnt/checkpoints/",
+  "file_tracker_table": "file_processing_tracker",
+  "file_tracker_database": "metadata",
+  "max_parallel_jobs": 4,
+  "retry_attempts": 3,
+  "timeout_minutes": 60,
+  "log_level": "INFO",
+  "enable_metrics": true,
+  "tables": [
+    {
+      "table_name": "customers",
+      "database_name": "analytics",
+      "source_path_pattern": "/mnt/raw/customers/*.parquet",
+      "loading_strategy": "scd2",
+      "primary_keys": [
+        "customer_id"
+      ],
+      "tracking_columns": [
+        "name",
+        "email",
+        "address"
+      ],
+      "file_format": "parquet",
+      "schema_evolution": true,
+      "partition_columns": [
+        "date_partition"
+      ]
+    },
+    {
+      "table_name": "transactions",
+      "database_name": "analytics",
+      "source_path_pattern": "/mnt/raw/transactions/*.parquet",
+      "loading_strategy": "append",
+      "file_format": "parquet",
+      "schema_evolution": true,
+      "partition_columns": [
+        "transaction_date"
+      ]
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "databricks-data-loader"
+version = "0.1.0"
+description = "A parallel data loading module for Databricks"
+authors = ["Infinit3Labs"]
+packages = [{ include = "data_loader" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pyspark = ">=3.0.0"
+delta-spark = ">=2.0.0"
+pydantic = ">=2.0.0"
+typer = ">=0.9.0"
+loguru = ">=0.7.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0.0"
+pytest-cov = ">=4.0.0"
+black = ">=23.0.0"
+flake8 = ">=6.0.0"
+mypy = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `job_runner` module to run loader as a Databricks job
- document Databricks job usage and add developer checklist
- provide demo script and example config
- enable Poetry with `pyproject.toml`
- test job parameter loading and patch Spark in existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cae14aab083269e842a4149d10daf