### PR TITLE
Add pipeline state management

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -8,3 +8,4 @@
 - [ ] Converted configuration management to YAML and env vars
 - [ ] Updated documentation and examples
 - [ ] Added config merging demo script
+- [ ] Implemented pipeline state management and restart capability

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A comprehensive data loading module for Databricks that provides parallel file p
 
 New users should start with the [Quickstart guide](docs/quickstart.md) which
 explains installation using **Poetry** and demonstrates the configuration
-workflow using a small demo.
+workflow using a small demo. See [Pipeline State Management](docs/pipeline_state.md)
+for details on restarting interrupted runs.
 
 ## Features
 
@@ -19,6 +20,7 @@ workflow using a small demo.
 - **Schema Evolution**: Automatic schema evolution support
 - **Error Handling**: Robust error handling with configurable retry logic
 - **Monitoring**: Comprehensive logging and metrics collection
+- **State Management**: Pipeline progress saved to disk for safe restarts
 - **Optimization**: Automatic table optimization and vacuum operations
 - **🆕 Cluster Mode**: Enhanced Databricks cluster integration with:
   - Automatic environment detection and optimization

--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -8,7 +8,7 @@ A comprehensive data loading module for Databricks that provides:
 - Robust error handling and logging
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __author__ = "Infinit3Labs"
 
 # Import only non-Spark dependent modules by default
@@ -20,32 +20,43 @@ from .config.table_config import (
     EXAMPLE_CONFIG,
     load_config_from_file,
 )
+from .core.state_manager import PipelineStateManager, PipelineStageStatus
 
 __all__ = [
     "DataLoaderConfig",
-    "TableConfig", 
+    "TableConfig",
     "LoadingStrategy",
     "EXAMPLE_CONFIG",
     "load_config_from_file",
+    "PipelineStateManager",
+    "PipelineStageStatus",
 ]
+
 
 # Provide easy access to main components when PySpark is available
 def get_data_processor(config):
     """Get DataProcessor instance (requires PySpark)."""
     from .core.processor import DataProcessor
+
     return DataProcessor(config)
+
 
 def get_file_tracker(database_name, table_name):
     """Get FileTracker instance (requires PySpark)."""
     from .core.file_tracker import FileTracker
+
     return FileTracker(database_name, table_name)
+
 
 def get_scd2_strategy(table_config):
     """Get SCD2Strategy instance (requires PySpark)."""
     from .strategies.scd2_strategy import SCD2Strategy
+
     return SCD2Strategy(table_config)
+
 
 def get_append_strategy(table_config):
     """Get AppendStrategy instance (requires PySpark)."""
     from .strategies.append_strategy import AppendStrategy
+
     return AppendStrategy(table_config)

--- a/data_loader/core/processor.py
+++ b/data_loader/core/processor.py
@@ -16,6 +16,7 @@ from ..config.databricks_config import databricks_config
 from ..core.file_tracker import FileTracker, FileProcessingStatus
 from ..core.parallel_executor import ParallelExecutor, ProcessingTask, ProcessingResult
 from ..strategies.base_strategy import BaseLoadingStrategy
+from ..core.state_manager import PipelineStateManager, PipelineStageStatus
 from ..strategies.scd2_strategy import SCD2Strategy
 from ..strategies.append_strategy import AppendStrategy
 
@@ -23,7 +24,7 @@ from ..strategies.append_strategy import AppendStrategy
 class DataProcessor:
     """
     Main orchestrator for the data loading pipeline.
-    
+
     Responsibilities:
     - Discover new files based on configuration patterns
     - Track file processing status
@@ -32,43 +33,50 @@ class DataProcessor:
     - Handle errors and retries
     - Provide monitoring and metrics
     """
-    
+
     def __init__(self, config: DataLoaderConfig):
         """
         Initialize the data processor.
-        
+
         Args:
             config: Configuration for the data loader
         """
         self.config = config
-        
+
         # Initialize components
         self.file_tracker = FileTracker(
             database_name=config.file_tracker_database,
-            table_name=config.file_tracker_table
+            table_name=config.file_tracker_table,
         )
-        
+
         self.parallel_executor = ParallelExecutor(
-            max_workers=config.max_parallel_jobs,
-            timeout_minutes=config.timeout_minutes
+            max_workers=config.max_parallel_jobs, timeout_minutes=config.timeout_minutes
         )
         self.parallel_executor.set_file_tracker(self.file_tracker)
-        
+
+        # Pipeline state manager
+        self.state_manager = PipelineStateManager(
+            config.checkpoint_path,
+            config.state_file,
+        )
+
         # Cache for loading strategies
         self._strategy_cache: Dict[str, BaseLoadingStrategy] = {}
-        
-        logger.info(f"Initialized DataProcessor with {len(config.tables)} table configurations")
-    
+
+        logger.info(
+            f"Initialized DataProcessor with {len(config.tables)} table configurations"
+        )
+
     def process_all_tables(self) -> Dict[str, Any]:
         """
         Process all configured tables by discovering and loading new files.
-        
+
         Returns:
             Dictionary with overall processing results and metrics
         """
         logger.info("Starting data processing for all configured tables")
         start_time = time.time()
-        
+
         overall_results = {
             "processing_start_time": start_time,
             "tables_processed": 0,
@@ -77,65 +85,105 @@ class DataProcessor:
             "successful_files": 0,
             "failed_files": 0,
             "table_results": {},
-            "errors": []
+            "errors": [],
         }
-        
+
         try:
             # Process each table configuration
             for table_config in self.config.tables:
+                table_status = self.state_manager.get_table_status(
+                    table_config.table_name
+                )
+                if table_status == PipelineStageStatus.COMPLETED:
+                    logger.info(
+                        f"Skipping table {table_config.table_name} - already completed"
+                    )
+                    continue
+
                 logger.info(f"Processing table: {table_config.table_name}")
-                
+                self.state_manager.update_table_status(
+                    table_config.table_name, PipelineStageStatus.IN_PROGRESS
+                )
+
                 try:
                     table_result = self.process_table(table_config)
-                    overall_results["table_results"][table_config.table_name] = table_result
+                    overall_results["table_results"][
+                        table_config.table_name
+                    ] = table_result
                     overall_results["tables_processed"] += 1
-                    overall_results["total_files_discovered"] += table_result.get("files_discovered", 0)
-                    overall_results["total_files_processed"] += table_result.get("files_processed", 0)
-                    overall_results["successful_files"] += table_result.get("successful_files", 0)
-                    overall_results["failed_files"] += table_result.get("failed_files", 0)
-                    
+                    overall_results["total_files_discovered"] += table_result.get(
+                        "files_discovered", 0
+                    )
+                    overall_results["total_files_processed"] += table_result.get(
+                        "files_processed", 0
+                    )
+                    overall_results["successful_files"] += table_result.get(
+                        "successful_files", 0
+                    )
+                    overall_results["failed_files"] += table_result.get(
+                        "failed_files", 0
+                    )
+                    self.state_manager.update_table_status(
+                        table_config.table_name,
+                        PipelineStageStatus.COMPLETED,
+                        {"summary": table_result},
+                    )
+
                 except Exception as e:
-                    error_msg = f"Error processing table {table_config.table_name}: {str(e)}"
+                    error_msg = (
+                        f"Error processing table {table_config.table_name}: {str(e)}"
+                    )
                     logger.error(error_msg)
                     overall_results["errors"].append(error_msg)
                     overall_results["table_results"][table_config.table_name] = {
                         "success": False,
-                        "error": error_msg
+                        "error": error_msg,
                     }
-            
+                    self.state_manager.update_table_status(
+                        table_config.table_name,
+                        PipelineStageStatus.FAILED,
+                        {"error": error_msg},
+                    )
+
             # Handle retries for failed files
             if overall_results["failed_files"] > 0:
                 logger.info("Processing retries for failed files")
                 retry_results = self.retry_failed_files()
                 overall_results["retry_results"] = retry_results
-        
+
         except Exception as e:
             error_msg = f"Critical error in process_all_tables: {str(e)}"
             logger.error(error_msg)
             overall_results["errors"].append(error_msg)
-        
+
         finally:
             overall_results["total_processing_time"] = time.time() - start_time
-            
-        logger.info(f"Completed processing all tables in {overall_results['total_processing_time']:.2f}s")
+
+        logger.info(
+            f"Completed processing all tables in {overall_results['total_processing_time']:.2f}s"
+        )
         return overall_results
-    
+
     def process_table(self, table_config: TableConfig) -> Dict[str, Any]:
         """
         Process a single table by discovering and loading new files.
-        
+
         Args:
             table_config: Configuration for the table to process
-            
+
         Returns:
             Dictionary with processing results for this table
         """
-        logger.info(f"Processing table {table_config.table_name} with strategy {table_config.loading_strategy}")
-        
+        logger.info(
+            f"Processing table {table_config.table_name} with strategy {table_config.loading_strategy}"
+        )
+
         # Discover new files
         discovered_files = self.discover_files(table_config)
-        logger.info(f"Discovered {len(discovered_files)} files for table {table_config.table_name}")
-        
+        logger.info(
+            f"Discovered {len(discovered_files)} files for table {table_config.table_name}"
+        )
+
         if not discovered_files:
             return {
                 "table_name": table_config.table_name,
@@ -143,45 +191,48 @@ class DataProcessor:
                 "files_processed": 0,
                 "successful_files": 0,
                 "failed_files": 0,
-                "processing_time": 0.0
+                "processing_time": 0.0,
             }
-        
+
         # Register new files with file tracker
-        new_files_count = self.file_tracker.register_files(discovered_files, table_config.table_name)
-        
+        new_files_count = self.file_tracker.register_files(
+            discovered_files, table_config.table_name
+        )
+
         # Get files pending processing
         pending_files = self.file_tracker.get_pending_files(table_config.table_name)
-        
+
         if not pending_files:
-            logger.info(f"No pending files to process for table {table_config.table_name}")
+            logger.info(
+                f"No pending files to process for table {table_config.table_name}"
+            )
             return {
                 "table_name": table_config.table_name,
                 "files_discovered": len(discovered_files),
                 "files_processed": 0,
                 "successful_files": 0,
                 "failed_files": 0,
-                "processing_time": 0.0
+                "processing_time": 0.0,
             }
-        
+
         # Create processing tasks
         tasks = [
             ProcessingTask(
                 file_path=file_path,
                 table_name=table_config.table_name,
                 strategy_name=table_config.loading_strategy.value,
-                max_retries=self.config.retry_attempts
+                max_retries=self.config.retry_attempts,
             )
             for file_path in pending_files
         ]
-        
+
         # Execute tasks in parallel
         start_time = time.time()
         execution_results = self.parallel_executor.execute_tasks(
-            tasks, 
-            self._process_single_file
+            tasks, self._process_single_file
         )
         processing_time = time.time() - start_time
-        
+
         # Compile results
         result = {
             "table_name": table_config.table_name,
@@ -191,18 +242,18 @@ class DataProcessor:
             "successful_files": execution_results["successful_tasks"],
             "failed_files": execution_results["failed_tasks"],
             "processing_time": processing_time,
-            "execution_details": execution_results
+            "execution_details": execution_results,
         }
-        
+
         return result
-    
+
     def discover_files(self, table_config: TableConfig) -> List[str]:
         """
         Discover files matching the table's source path pattern.
-        
+
         Args:
             table_config: Configuration for the table
-            
+
         Returns:
             List of file paths that match the pattern
         """
@@ -210,76 +261,78 @@ class DataProcessor:
             # Use glob to find files matching the pattern
             pattern = table_config.source_path_pattern
             discovered_files = glob.glob(pattern, recursive=True)
-            
+
             # Filter out directories and ensure we only get files
             file_paths = [f for f in discovered_files if Path(f).is_file()]
-            
+
             logger.debug(f"Pattern '{pattern}' matched {len(file_paths)} files")
             return file_paths
-            
+
         except Exception as e:
-            logger.error(f"Error discovering files for pattern {table_config.source_path_pattern}: {e}")
+            logger.error(
+                f"Error discovering files for pattern {table_config.source_path_pattern}: {e}"
+            )
             return []
-    
+
     def _process_single_file(self, task: ProcessingTask) -> ProcessingResult:
         """
         Process a single file using the appropriate loading strategy.
-        
+
         Args:
             task: Processing task containing file and table information
-            
+
         Returns:
             Processing result
         """
         start_time = time.time()
-        
+
         try:
             # Get table configuration
             table_config = self.config.get_table_config(task.table_name)
             if not table_config:
                 raise ValueError(f"No configuration found for table {task.table_name}")
-            
+
             # Get loading strategy
             strategy = self._get_loading_strategy(table_config)
-            
+
             # Prepare target table
             strategy.prepare_target_table()
-            
+
             # Read source data
             source_df = strategy.read_source_data(task.file_path)
-            
+
             # Load data using the strategy
             load_result = strategy.load_data(source_df, task.file_path)
-            
+
             execution_time = time.time() - start_time
-            
+
             return ProcessingResult(
                 file_path=task.file_path,
                 table_name=task.table_name,
                 success=True,
                 execution_time=execution_time,
-                metrics=load_result
+                metrics=load_result,
             )
-            
+
         except Exception as e:
             execution_time = time.time() - start_time
             error_msg = f"Error processing file {task.file_path}: {str(e)}"
-            
+
             return ProcessingResult(
                 file_path=task.file_path,
                 table_name=task.table_name,
                 success=False,
                 execution_time=execution_time,
-                error_message=error_msg
+                error_message=error_msg,
             )
-    
+
     def _get_loading_strategy(self, table_config: TableConfig) -> BaseLoadingStrategy:
         """
         Get the appropriate loading strategy for a table configuration.
-        
+
         Args:
             table_config: Table configuration
-            
+
         Returns:
             Loading strategy instance
         """
@@ -287,68 +340,78 @@ class DataProcessor:
         cache_key = f"{table_config.table_name}_{table_config.loading_strategy.value}"
         if cache_key in self._strategy_cache:
             return self._strategy_cache[cache_key]
-        
+
         # Create new strategy based on configuration
         if table_config.loading_strategy == LoadingStrategy.SCD2:
             strategy = SCD2Strategy(table_config)
         elif table_config.loading_strategy == LoadingStrategy.APPEND:
             strategy = AppendStrategy(table_config)
         else:
-            raise ValueError(f"Unsupported loading strategy: {table_config.loading_strategy}")
-        
+            raise ValueError(
+                f"Unsupported loading strategy: {table_config.loading_strategy}"
+            )
+
         # Validate strategy configuration
         if not strategy.validate_config():
-            raise ValueError(f"Invalid configuration for {table_config.loading_strategy} strategy")
-        
+            raise ValueError(
+                f"Invalid configuration for {table_config.loading_strategy} strategy"
+            )
+
         # Cache the strategy
         self._strategy_cache[cache_key] = strategy
-        
+
         return strategy
-    
+
     def retry_failed_files(self) -> Dict[str, Any]:
         """
         Retry processing files that failed but haven't exceeded retry limits.
-        
+
         Returns:
             Dictionary with retry results
         """
         logger.info("Starting retry processing for failed files")
-        
+
         # Get failed files that can be retried
         failed_files = self.file_tracker.get_failed_files(self.config.retry_attempts)
-        
+
         if not failed_files:
             logger.info("No failed files eligible for retry")
             return {"retry_tasks": 0, "successful_retries": 0, "failed_retries": 0}
-        
+
         # Create retry tasks
         retry_tasks = []
         for file_path in failed_files:
             # Find which table this file belongs to
             table_name = self._find_table_for_file(file_path)
             if table_name:
-                retry_tasks.append(ProcessingTask(
-                    file_path=file_path,
-                    table_name=table_name,
-                    strategy_name="",  # Will be determined during processing
-                    retry_count=1  # This would be properly tracked in real implementation
-                ))
-        
+                retry_tasks.append(
+                    ProcessingTask(
+                        file_path=file_path,
+                        table_name=table_name,
+                        strategy_name="",  # Will be determined during processing
+                        retry_count=1,  # This would be properly tracked in real implementation
+                    )
+                )
+
         # Execute retry tasks
         if retry_tasks:
-            retry_results = self.parallel_executor.execute_tasks(retry_tasks, self._process_single_file)
-            logger.info(f"Retry processing completed: {retry_results['successful_tasks']}/{len(retry_tasks)} successful")
+            retry_results = self.parallel_executor.execute_tasks(
+                retry_tasks, self._process_single_file
+            )
+            logger.info(
+                f"Retry processing completed: {retry_results['successful_tasks']}/{len(retry_tasks)} successful"
+            )
             return retry_results
         else:
             return {"retry_tasks": 0, "successful_retries": 0, "failed_retries": 0}
-    
+
     def _find_table_for_file(self, file_path: str) -> Optional[str]:
         """
         Find which table configuration matches a given file path.
-        
+
         Args:
             file_path: Path of the file
-            
+
         Returns:
             Table name if found, None otherwise
         """
@@ -358,23 +421,23 @@ class DataProcessor:
             if pattern in file_path:
                 return table_config.table_name
         return None
-    
+
     def get_processing_status(self) -> Dict[str, Any]:
         """
         Get current processing status and metrics.
-        
+
         Returns:
             Dictionary with processing status information
         """
         overall_stats = self.file_tracker.get_processing_stats()
-        
+
         # Get stats per table
         table_stats = {}
         for table_config in self.config.tables:
-            table_stats[table_config.table_name] = self.file_tracker.get_processing_stats(
+            table_stats[
                 table_config.table_name
-            )
-        
+            ] = self.file_tracker.get_processing_stats(table_config.table_name)
+
         return {
             "overall_statistics": overall_stats,
             "table_statistics": table_stats,
@@ -382,41 +445,45 @@ class DataProcessor:
                 "max_parallel_jobs": self.config.max_parallel_jobs,
                 "retry_attempts": self.config.retry_attempts,
                 "timeout_minutes": self.config.timeout_minutes,
-                "total_tables": len(self.config.tables)
-            }
+                "total_tables": len(self.config.tables),
+            },
         }
-    
+
     def cleanup_old_records(self, days_to_keep: int = 30):
         """
         Clean up old file tracking records.
-        
+
         Args:
             days_to_keep: Number of days to keep records
         """
         logger.info(f"Cleaning up file tracking records older than {days_to_keep} days")
         self.file_tracker.cleanup_old_records(days_to_keep)
-    
+
     def optimize_all_tables(self):
         """Run optimization on all configured tables."""
         logger.info("Running optimization on all configured tables")
-        
+
         for table_config in self.config.tables:
             try:
                 strategy = self._get_loading_strategy(table_config)
                 strategy.optimize_table()
                 logger.info(f"Optimized table {table_config.table_name}")
             except Exception as e:
-                logger.warning(f"Could not optimize table {table_config.table_name}: {e}")
-    
+                logger.warning(
+                    f"Could not optimize table {table_config.table_name}: {e}"
+                )
+
     def vacuum_all_tables(self, retention_hours: int = 168):
         """
         Run VACUUM on all configured tables.
-        
+
         Args:
             retention_hours: Retention period in hours
         """
-        logger.info(f"Running VACUUM on all configured tables with {retention_hours}h retention")
-        
+        logger.info(
+            f"Running VACUUM on all configured tables with {retention_hours}h retention"
+        )
+
         for table_config in self.config.tables:
             try:
                 strategy = self._get_loading_strategy(table_config)
@@ -424,3 +491,7 @@ class DataProcessor:
                 logger.info(f"Vacuumed table {table_config.table_name}")
             except Exception as e:
                 logger.warning(f"Could not vacuum table {table_config.table_name}: {e}")
+
+    def reset_pipeline_state(self) -> None:
+        """Reset saved pipeline state."""
+        self.state_manager.reset()

--- a/data_loader/core/state_manager.py
+++ b/data_loader/core/state_manager.py
@@ -43,8 +43,11 @@ class PipelineStateManager:
 
     def save_state(self) -> None:
         self.checkpoint_path.mkdir(parents=True, exist_ok=True)
-        with open(self.state_file, "w", encoding="utf-8") as fh:
-            json.dump(self.state, fh, indent=2)
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as fh:
+                json.dump(self.state, fh, indent=2)
+        except (IOError, PermissionError, OSError) as e:
+            raise RuntimeError(f"Failed to save state to {self.state_file}: {e}") from e
 
     def get_table_status(self, table_name: str) -> PipelineStageStatus:
         entry = self.state.get("tables", {}).get(table_name)

--- a/data_loader/core/state_manager.py
+++ b/data_loader/core/state_manager.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Pipeline state management for tracking progress and supporting restarts."""
+
+import json
+from enum import Enum
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any
+
+
+class PipelineStageStatus(str, Enum):
+    """Status of a pipeline stage."""
+
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class PipelineStateManager:
+    """Manage pipeline state persistence in a JSON file."""
+
+    def __init__(self, checkpoint_path: str, state_file: str = "pipeline_state.json"):
+        self.checkpoint_path = Path(checkpoint_path)
+        self.state_file = self.checkpoint_path / state_file
+        self.state: Dict[str, Any] = {"tables": {}}
+        self._load_state()
+
+    def _load_state(self) -> None:
+        if self.state_file.exists():
+            with open(self.state_file, "r", encoding="utf-8") as fh:
+                self.state = json.load(fh)
+        else:
+            self.state = {"tables": {}}
+
+    def save_state(self) -> None:
+        self.checkpoint_path.mkdir(parents=True, exist_ok=True)
+        with open(self.state_file, "w", encoding="utf-8") as fh:
+            json.dump(self.state, fh, indent=2)
+
+    def get_table_status(self, table_name: str) -> PipelineStageStatus:
+        entry = self.state.get("tables", {}).get(table_name)
+        if entry:
+            return PipelineStageStatus(
+                entry.get("status", PipelineStageStatus.NOT_STARTED.value)
+            )
+        return PipelineStageStatus.NOT_STARTED
+
+    def update_table_status(
+        self,
+        table_name: str,
+        status: PipelineStageStatus,
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        entry = self.state.setdefault("tables", {}).get(table_name, {})
+        entry["status"] = status.value
+        entry["last_updated"] = datetime.utcnow().isoformat()
+        if details is not None:
+            entry["details"] = details
+        self.state["tables"][table_name] = entry
+        self.save_state()
+
+    def reset(self) -> None:
+        self.state = {"tables": {}}
+        self.save_state()

--- a/data_loader/core/state_manager.py
+++ b/data_loader/core/state_manager.py
@@ -29,8 +29,15 @@ class PipelineStateManager:
 
     def _load_state(self) -> None:
         if self.state_file.exists():
-            with open(self.state_file, "r", encoding="utf-8") as fh:
-                self.state = json.load(fh)
+            try:
+                with open(self.state_file, "r", encoding="utf-8") as fh:
+                    self.state = json.load(fh)
+            except (IOError, PermissionError) as e:
+                print(f"Error reading state file {self.state_file}: {e}")
+                self.state = {"tables": {}}
+            except json.JSONDecodeError as e:
+                print(f"Invalid JSON in state file {self.state_file}: {e}")
+                self.state = {"tables": {}}
         else:
             self.state = {"tables": {}}
 

--- a/data_loader/tests/test_state_manager.py
+++ b/data_loader/tests/test_state_manager.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock, patch
+from data_loader.core.state_manager import PipelineStateManager, PipelineStageStatus
+from data_loader.config.table_config import DataLoaderConfig, EXAMPLE_CONFIG
+from data_loader.core.processor import DataProcessor
+from data_loader.config.databricks_config import DatabricksConfig
+
+
+def test_pipeline_state_manager(tmp_path):
+    manager = PipelineStateManager(tmp_path)
+    manager.reset()
+    assert manager.get_table_status("t1") == PipelineStageStatus.NOT_STARTED
+    manager.update_table_status("t1", PipelineStageStatus.IN_PROGRESS)
+    assert manager.get_table_status("t1") == PipelineStageStatus.IN_PROGRESS
+    manager.update_table_status("t1", PipelineStageStatus.COMPLETED)
+    assert manager.get_table_status("t1") == PipelineStageStatus.COMPLETED
+
+    # Reload
+    manager2 = PipelineStateManager(tmp_path)
+    assert manager2.get_table_status("t1") == PipelineStageStatus.COMPLETED
+
+
+class DummyFileTracker:
+    def __init__(self, *a, **k):
+        pass
+
+
+@patch.object(DatabricksConfig, "spark", property(lambda self: Mock()))
+@patch("data_loader.core.processor.FileTracker", DummyFileTracker)
+def test_processor_skips_completed(tmp_path, monkeypatch):
+    cfg = EXAMPLE_CONFIG.copy()
+    cfg["checkpoint_path"] = str(tmp_path)
+    config = DataLoaderConfig(**cfg)
+
+    processor = DataProcessor(config)
+    monkeypatch.setattr(
+        processor,
+        "process_table",
+        lambda tc: {
+            "files_discovered": 0,
+            "files_processed": 0,
+            "successful_files": 0,
+            "failed_files": 0,
+        },
+    )
+
+    # First run processes all tables
+    result1 = processor.process_all_tables()
+    assert result1["tables_processed"] == len(config.tables)
+
+    # Second run should skip because state marks tables as completed
+    processor2 = DataProcessor(config)
+    monkeypatch.setattr(processor2, "process_table", lambda tc: {"files_discovered": 0})
+    result2 = processor2.process_all_tables()
+    assert result2["tables_processed"] == 0

--- a/demo/state_management_demo.py
+++ b/demo/state_management_demo.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from data_loader.core.state_manager import PipelineStateManager, PipelineStageStatus
+
+
+def main() -> None:
+    checkpoint = Path(__file__).parent / "state_checkpoint"
+    manager = PipelineStateManager(checkpoint)
+    manager.reset()
+
+    # Simulate processing two tables
+    manager.update_table_status("customers", PipelineStageStatus.IN_PROGRESS)
+    manager.update_table_status(
+        "customers", PipelineStageStatus.COMPLETED, {"rows": 10}
+    )
+    manager.update_table_status(
+        "transactions", PipelineStageStatus.FAILED, {"error": "network"}
+    )
+
+    print("Saved state:\n", manager.state)
+
+    # Reload to demonstrate persistence
+    manager2 = PipelineStateManager(checkpoint)
+    print("Loaded state after restart:\n", manager2.state)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pipeline_state.md
+++ b/docs/pipeline_state.md
@@ -1,0 +1,20 @@
+# Pipeline State Management
+
+The loader now persists pipeline progress in a JSON file so that interrupted runs can resume.
+
+## How it works
+
+- Each table has a status of `not_started`, `in_progress`, `completed` or `failed`.
+- The status is stored under the configured `checkpoint_path` using the filename defined by `state_file` in the configuration (default: `pipeline_state.json`).
+- The `PipelineStateManager` automatically loads this file on startup and updates it after each table is processed.
+- When `process_all_tables` runs, tables already marked as `completed` are skipped making the operation idempotent.
+
+## Resetting State
+
+Call `DataProcessor.reset_pipeline_state()` to clear the saved state and process all tables from the beginning.
+
+## Example
+
+```bash
+poetry run python demo/state_management_demo.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-data-loader"
-version = "0.1.0"
+version = "0.2.0"
 description = "A parallel data loading module for Databricks with file monitoring and multiple loading strategies"
 authors = ["Infinit3Labs <contact@infinit3labs.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- implement PipelineStateManager to track table progress
- expose new manager in package init
- persist pipeline state via DataProcessor
- support resetting pipeline state
- document state management and demo script
- add unit tests
- bump version to 0.2.0

## Testing
- `black data_loader/core/state_manager.py data_loader/tests/test_state_manager.py data_loader/core/processor.py data_loader/__init__.py data_loader/config/table_config.py demo/state_management_demo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcacd93048326895d7b9eec769edf