### PR TITLE
Add reset-state command

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -9,3 +9,4 @@
 - [x] Updated documentation and examples
 - [x] Added config merging demo script
 - [x] Implemented pipeline state management and restart capability
+- [ ] Added CLI command to reset pipeline state

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -9,4 +9,4 @@
 - [x] Updated documentation and examples
 - [x] Added config merging demo script
 - [x] Implemented pipeline state management and restart capability
-- [ ] Added CLI command to reset pipeline state
+- [x] Added CLI command to reset pipeline state

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ for details on restarting interrupted runs.
 - **Error Handling**: Robust error handling with configurable retry logic
 - **Monitoring**: Comprehensive logging and metrics collection
 - **State Management**: Pipeline progress saved to disk for safe restarts
+- **Reset Command**: Easily clear saved state with `reset-state`
 - **Optimization**: Automatic table optimization and vacuum operations
 - **🆕 Cluster Mode**: Enhanced Databricks cluster integration with:
   - Automatic environment detection and optimization
@@ -68,6 +69,9 @@ poetry run python demo/config_merge_demo.py
 
 # Showcase pipeline state management
 poetry run python demo/state_management_demo.py
+
+# Reset pipeline state
+poetry run python demo/reset_state_demo.py
 
 # Full example usage script
 poetry run python example_usage.py

--- a/data_loader/main.py
+++ b/data_loader/main.py
@@ -465,9 +465,42 @@ def create_example_config(
         
         print(f"Example configuration created: {output_file}")
         print("Edit this file to match your environment and table requirements.")
-        
+
     except Exception as e:
         logger.error(f"Failed to create example config: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def reset_state(
+    config_file: str = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to configuration YAML file",
+    ),
+    config_json: str = typer.Option(
+        None,
+        "--config-json",
+        help="Configuration as JSON string",
+    ),
+):
+    """Reset saved pipeline state using the provided configuration."""
+
+    setup_logging(log_level="INFO")
+
+    try:
+        config = load_configuration(config_file, config_json)
+        from data_loader.core.processor import DataProcessor
+
+        processor = DataProcessor(config)
+        processor.reset_pipeline_state()
+        print(
+            f"Pipeline state reset at {config.checkpoint_path}/{config.state_file}"
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to reset state: {e}")
         raise typer.Exit(1)
 
 

--- a/data_loader/tests/test_cli_reset_state.py
+++ b/data_loader/tests/test_cli_reset_state.py
@@ -1,0 +1,17 @@
+from typer.testing import CliRunner
+from data_loader.main import app
+from data_loader.config import EXAMPLE_CONFIG
+import yaml
+from unittest.mock import patch
+
+
+def test_reset_state_command(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    with open(cfg_file, "w") as fh:
+        yaml.safe_dump(EXAMPLE_CONFIG, fh)
+
+    runner = CliRunner()
+    with patch("data_loader.core.processor.DataProcessor") as mock_proc:
+        result = runner.invoke(app, ["reset-state", "--config", str(cfg_file)])
+        assert result.exit_code == 0
+        mock_proc.return_value.reset_pipeline_state.assert_called_once()

--- a/demo/reset_state_demo.py
+++ b/demo/reset_state_demo.py
@@ -1,0 +1,16 @@
+"""Demo for resetting the pipeline state using configuration."""
+from pathlib import Path
+from data_loader.config import load_config_from_file
+from data_loader.core.processor import DataProcessor
+
+
+def main() -> None:
+    cfg_path = Path(__file__).parent / "demo_config.yaml"
+    config = load_config_from_file(str(cfg_path))
+    processor = DataProcessor(config)
+    processor.reset_pipeline_state()
+    print("Pipeline state reset for demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/reset_state.md
+++ b/docs/reset_state.md
@@ -1,0 +1,10 @@
+# Resetting Pipeline State
+
+The loader persists progress under the configured `checkpoint_path` so interrupted runs can be resumed.
+Use the `reset-state` command to clear this saved state.
+
+```bash
+python -m data_loader.main reset-state --config path/to/config.yaml
+```
+
+The command loads the configuration (including any environment overrides) and deletes the saved pipeline state file. Use this when you want to restart processing from scratch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-data-loader"
-version = "0.2.0"
+version = "0.2.1"
 description = "A parallel data loading module for Databricks with file monitoring and multiple loading strategies"
 authors = ["Infinit3Labs <contact@infinit3labs.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- introduce `reset-state` CLI command for clearing pipeline state
- document new command and demo in README
- add `reset_state_demo.py` example
- provide docs for resetting state
- test new CLI command
- bump version to 0.2.1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688007da3af88326b28141d532c1c138